### PR TITLE
Add ReturnsNull to MoqExtensions

### DIFF
--- a/Emmersion.Testing/MoqExtensions.cs
+++ b/Emmersion.Testing/MoqExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 using Moq;
+using Moq.Language.Flow;
 
 namespace Emmersion.Testing
 {

--- a/Emmersion.Testing/MoqExtensions.cs
+++ b/Emmersion.Testing/MoqExtensions.cs
@@ -17,5 +17,18 @@ namespace Emmersion.Testing
         {
             mock.Verify(expression, Times.Never);
         }
+        
+        public static IReturnsResult<TMock> ReturnsNull<TMock, TResult>(this ISetup<TMock, TResult> mock)
+            where TMock : class
+        {
+            return mock.Returns<TResult>(null);   
+        }
+
+        public static IReturnsResult<TMock> ReturnsNullAsync<TMock, TResult>(this ISetup<TMock, Task<TResult>> mock)
+            where TMock : class 
+            where TResult: class
+        {
+            return mock.ReturnsAsync((TResult)null);
+        }
     }
 }


### PR DESCRIPTION
Allan and I got tired of the the Returns((Foo)null) pattern everywhere. This allows the following, more fluent mock setup:

```
GetMock<IFoo>().Setup(x => x.DoTheThing()).ReturnsNullAsync();
```